### PR TITLE
[eng-2369] don't add negative suffix and prefix length to the total cont...

### DIFF
--- a/src/main/java/com/sonian/elasticsearch/http/jetty/JettyHttpServerRestChannel.java
+++ b/src/main/java/com/sonian/elasticsearch/http/jetty/JettyHttpServerRestChannel.java
@@ -66,7 +66,13 @@ public class JettyHttpServerRestChannel implements HttpChannel {
             resp.addHeader("Access-Control-Allow-Headers", "X-Requested-With");
         }
         try {
-            int contentLength = response.contentLength() + response.prefixContentLength() + response.suffixContentLength();
+            int contentLength = response.contentLength();
+            if (response.prefixContentLength() > 0) {
+                contentLength += response.prefixContentLength();
+            }
+            if (response.suffixContentLength() > 0) {
+                contentLength += response.suffixContentLength();
+            }
             resp.setContentLength(contentLength);
             ServletOutputStream out = resp.getOutputStream();
             if (response.prefixContent() != null) {


### PR DESCRIPTION
...ent length

Suffix and prefix lengths reported by RestResponse can be -1. This is default behavior implemented in [AbstractRestResponse](https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/rest/AbstractRestResponse.java#L34).

Fixes #20
