### PR TITLE
Support for Elasticsearch v1.4

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -5,6 +5,7 @@ h2. Compatibility
 The following table shows the versions of elasticsearch and jetty that Jetty Plugin was built with.
 
 |_. Jetty Plugin |_.  Elasticsearch    |_.  Jetty  |
+| 1.4.4 | 1.4.4    | 8.1.14.v20131031 |
 | 1.2.1 | 1.2.1    | 8.1.14.v20131031 |
 | 1.1.1-beta | 1.1.1    | 8.1.14.v20131031 |
 | 1.1.0-beta | 1.1.0    | 8.1.14.v20131031 |
@@ -37,7 +38,7 @@ $ bin/plugin -url https://oss-es-plugins.s3.amazonaws.com/elasticsearch-jetty/el
 The core of the plugin is JettyHttpServerTransport module that works as a replacement for NettyHttpServerTransport. To enable the elasticsearch-jetty plugin, the default netty http transport should be replaced with jetty http transport by adding the following line to @elasticsearch.yml@.
 
 <pre>
-http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransportModule
+http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransport
 </pre>
 
 The elasticsearch-jetty plugin adds @Server: Jetty(8.1.4.v20120524)@ header to all responses. So, it's possible to verify that jetty plugin is running by checking the response headers using the following curl command:
@@ -109,7 +110,7 @@ After the login service is configured, the next step is to set security constrai
 The following settings in @elasticsearch.yml@ will enable granular restrictions:
 
 <pre>
-http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransportModule
+http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransport
 sonian.elasticsearch.http.jetty:
     config: jetty.xml,jetty-hash-auth.xml,jetty-restrict-writes.xml
 </pre>
@@ -117,7 +118,7 @@ sonian.elasticsearch.http.jetty:
 Authentication can be used with SSL connector. The following settings will restrict access to all pages and enable SSL connector:
 
 <pre>
-http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransportModule
+http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransport
 sonian.elasticsearch.http.jetty:
     config: jetty.xml,jetty-ssl.xml,jetty-hash-auth.xml,jetty-restrict-all.xml
     ssl_port: 9443
@@ -128,15 +129,15 @@ Security constraints in the elasticsearch-jetty plugin is very similar to securi
 
 h3. Request Logging
 
-The elasticsearch-jetty plugin contains two versions of the HTTP Server Transport: @JettyHttpServerTransport@ and @FilterHttpTransportModule@. While @JettyHttpServerTransport@ uses Jetty to handle all incoming requests, @FilterHttpTransportModule@ simply wraps another HTTP Server Transport (@JettyHttpServerTransport@ by default) to filter requests and responses. @FilterHttpTransportModule@ can be configured to pass all incoming requests through a chain of filters. The elasticsearch-jetty plugin contains one such filter that can be used for request logging.
+The elasticsearch-jetty plugin contains two versions of the HTTP Server Transport: @JettyHttpServerTransport@ and @FilterHttpServerTransport@. While @JettyHttpServerTransport@ uses Jetty to handle all incoming requests, @FilterHttpServerTransport@ simply wraps another HTTP Server Transport (@JettyHttpServerTransport@ by default) to filter requests and responses. @FilterHttpServerTransport@ can be configured to pass all incoming requests through a chain of filters. The elasticsearch-jetty plugin contains one such filter that can be used for request logging.
 
-In order to setup request logging, elasticsearch should be switched to use @FilterHttpTransportModule@. It can be done by the following setting:
+In order to setup request logging, elasticsearch should be switched to use @FilterHttpServerTransport@. It can be done by the following setting:
 
 <pre>
-http.type: com.sonian.elasticsearch.http.filter.FilterHttpServerTransportModule
+http.type: com.sonian.elasticsearch.http.filter.FilterHttpServerTransport
 </pre>
 
-Then @FilterHttpTransportModule@ has to be configured with an appropriate filter:
+Then @FilterHttpServerTransport@ has to be configured with an appropriate filter:
 
 <pre>
 sonian.elasticsearch.http.filter:

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,9 +1,9 @@
 cluster.name: jetty-test
 # Switch to jetty transport without filter
-#http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransportModule
+#http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransport
 
 # Switch to jetty transport with filter
-http.type: com.sonian.elasticsearch.http.filter.FilterHttpServerTransportModule
+http.type: com.sonian.elasticsearch.http.filter.FilterHttpServerTransport
 
 # Filter setup
 sonian.elasticsearch.http.filter:

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,9 +1,12 @@
 cluster.name: jetty-test
-# Switch to jetty transport without filter
-#http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransport
 
-# Switch to jetty transport with filter
-http.type: com.sonian.elasticsearch.http.filter.FilterHttpServerTransport
+# Transport Setup
+sonian.elasticsearch:
+    # Default to jetty transport without filter
+    #http.type: com.sonian.elasticsearch.http.jetty.JettyHttpServerTransport
+
+    # Uncomment to switch to jetty transport with filter
+    #http.type: com.sonian.elasticsearch.http.filter.FilterHttpServerTransport
 
 # Filter setup
 sonian.elasticsearch.http.filter:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sonian</groupId>
   <artifactId>elasticsearch-jetty</artifactId>
-  <version>1.2.3-beta</version>
+  <version>1.4.4</version>
   <packaging>jar</packaging>
   <description>Jetty plugin for ElasticSearch</description>
   <inceptionYear>2011</inceptionYear>
@@ -70,7 +70,7 @@
   </parent>
 
   <properties>
-    <elasticsearch.version>1.2.3</elasticsearch.version>
+    <elasticsearch.version>1.4.4</elasticsearch.version>
     <jetty.version>8.1.14.v20131031</jetty.version>
     <github.global.server>github</github.global.server>
   </properties>

--- a/src/main/java/com/sonian/elasticsearch/http/filter/FilterHttpServerTransportModule.java
+++ b/src/main/java/com/sonian/elasticsearch/http/filter/FilterHttpServerTransportModule.java
@@ -39,11 +39,11 @@ public class FilterHttpServerTransportModule extends AbstractModule {
         componentSettings = settings.getComponentSettings(this.getClass());
     }
 
-
+	@SuppressWarnings({"unchecked"})
     @Override
     protected void configure() {
-        bind(HttpServerTransport.class)
-                .to(FilterHttpServerTransport.class).asEagerSingleton();
+        // this transport has already been bound by http server module
+//        bind(HttpServerTransport.class).to(FilterHttpServerTransport.class).asEagerSingleton();
         Class<? extends HttpServerTransport> transport;
         // This is a hack for debugging. It allows switching back to NettyHttpServer if needed.
         // HttpServerTransportModule should be loaded instead of just binding HttpServerTransport

--- a/src/main/java/com/sonian/elasticsearch/http/filter/FilterHttpServerTransportModule.java
+++ b/src/main/java/com/sonian/elasticsearch/http/filter/FilterHttpServerTransportModule.java
@@ -42,8 +42,6 @@ public class FilterHttpServerTransportModule extends AbstractModule {
 	@SuppressWarnings({"unchecked"})
     @Override
     protected void configure() {
-        // this transport has already been bound by http server module
-//        bind(HttpServerTransport.class).to(FilterHttpServerTransport.class).asEagerSingleton();
         Class<? extends HttpServerTransport> transport;
         // This is a hack for debugging. It allows switching back to NettyHttpServer if needed.
         // HttpServerTransportModule should be loaded instead of just binding HttpServerTransport

--- a/src/main/java/com/sonian/elasticsearch/http/jetty/JettyHttpServerTransportModule.java
+++ b/src/main/java/com/sonian/elasticsearch/http/jetty/JettyHttpServerTransportModule.java
@@ -31,8 +31,6 @@ public class JettyHttpServerTransportModule extends AbstractModule {
 
     @SuppressWarnings({"unchecked"})
     @Override protected void configure() {
-        // this transport has already been bound by http server module
-//        bind(HttpServerTransport.class).to(JettyHttpServerTransport.class).asEagerSingleton();
         bind(ESLoggerWrapper.class).asEagerSingleton();
     }
 }

--- a/src/main/java/com/sonian/elasticsearch/http/jetty/JettyHttpServerTransportModule.java
+++ b/src/main/java/com/sonian/elasticsearch/http/jetty/JettyHttpServerTransportModule.java
@@ -16,15 +16,23 @@
 package com.sonian.elasticsearch.http.jetty;
 
 import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.common.settings.Settings;
 
 /**
  * @author imotov
  */
 public class JettyHttpServerTransportModule extends AbstractModule {
 
+    private final Settings settings;
+
+    public JettyHttpServerTransportModule(Settings settings) {
+        this.settings = settings;
+    }
+
+    @SuppressWarnings({"unchecked"})
     @Override protected void configure() {
-        bind(HttpServerTransport.class).to(JettyHttpServerTransport.class).asEagerSingleton();
+        // this transport has already been bound by http server module
+//        bind(HttpServerTransport.class).to(JettyHttpServerTransport.class).asEagerSingleton();
         bind(ESLoggerWrapper.class).asEagerSingleton();
     }
 }

--- a/src/main/resources/config/jetty.xml
+++ b/src/main/resources/config/jetty.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<Configure id="ESServer" class="org.eclipse.jetty.server.Server">
+
+    <!-- ==================================================== -->
+    <!-- ElasticSearch Handler.                               -->
+    <!-- This handler redirects all requests to ElasticSearch -->
+    <!-- ==================================================== -->
+    <Set name="handler">
+        <New class="com.sonian.elasticsearch.http.jetty.handler.JettyHttpServerTransportHandler"
+             id="HttpServerAdapterHandler">
+            <Set name="transport"><Ref id="ESServerTransport"/></Set>
+        </New>
+    </Set>
+
+    <!-- ==================================================== -->
+    <!--   Reduce verbosity of jetty default error handler    -->
+    <!-- ==================================================== -->
+    <Call name="addBean">
+        <Arg>
+            <New class="com.sonian.elasticsearch.http.jetty.error.JettyHttpServerErrorHandler"
+                 id="HttpServerErrorHandler">
+            </New>
+        </Arg>
+    </Call>
+
+    <!-- ======================================== -->
+    <!--         Add HTTP connector               -->
+    <!-- ======================================== -->
+    <Call name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.server.nio.SelectChannelConnector">
+                <Set name="host"><Property name="jetty.bind_host"/></Set>
+                <Set name="port"><Property name="jetty.port"/></Set>
+                <Set name="maxIdleTime">600000</Set>
+                <Set name="Acceptors">2</Set>
+            </New>
+        </Arg>
+    </Call>
+
+</Configure>

--- a/src/test/java/com/sonian/elasticsearch/http/filter/logging/JsonLoggingFilterHttpServerAdapterTests.java
+++ b/src/test/java/com/sonian/elasticsearch/http/filter/logging/JsonLoggingFilterHttpServerAdapterTests.java
@@ -16,23 +16,18 @@
 package com.sonian.elasticsearch.http.filter.logging;
 
 import com.sonian.elasticsearch.http.filter.FilterHttpServerTransport;
-import com.sonian.elasticsearch.http.filter.FilterHttpServerTransportModule;
 import com.sonian.elasticsearch.http.jetty.AbstractJettyHttpServerTests;
 import com.sonian.elasticsearch.http.jetty.HttpClientResponse;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.http.HttpServerTransport;
-import org.elasticsearch.node.internal.InternalNode;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
-import static com.sonian.elasticsearch.http.filter.logging.RequestLoggingLevel.Level.TRACE;
-import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -48,7 +43,7 @@ public class JsonLoggingFilterHttpServerAdapterTests extends AbstractJettyHttpSe
         mockESLoggerFactory = new MockESLoggerFactory("INFO", "com.sonian.elasticsearch.http.filter.jsonlog");
         ESLoggerFactory.setDefaultFactory(mockESLoggerFactory);
         putDefaultSettings(ImmutableSettings.settingsBuilder()
-                .put("http.type", FilterHttpServerTransportModule.class.getName())
+                .put("http.type", FilterHttpServerTransport.class.getName())
         );
     }
 

--- a/src/test/java/com/sonian/elasticsearch/http/filter/logging/JsonLoggingFilterHttpServerAdapterTests.java
+++ b/src/test/java/com/sonian/elasticsearch/http/filter/logging/JsonLoggingFilterHttpServerAdapterTests.java
@@ -43,7 +43,7 @@ public class JsonLoggingFilterHttpServerAdapterTests extends AbstractJettyHttpSe
         mockESLoggerFactory = new MockESLoggerFactory("INFO", "com.sonian.elasticsearch.http.filter.jsonlog");
         ESLoggerFactory.setDefaultFactory(mockESLoggerFactory);
         putDefaultSettings(ImmutableSettings.settingsBuilder()
-                .put("http.type", FilterHttpServerTransport.class.getName())
+                .put("sonian.elasticsearch.http.type", FilterHttpServerTransport.class.getName())
         );
     }
 

--- a/src/test/java/com/sonian/elasticsearch/http/filter/logging/LoggingFilterHttpServerAdapterTests.java
+++ b/src/test/java/com/sonian/elasticsearch/http/filter/logging/LoggingFilterHttpServerAdapterTests.java
@@ -16,13 +16,9 @@
 package com.sonian.elasticsearch.http.filter.logging;
 
 import com.sonian.elasticsearch.http.filter.FilterHttpServerTransport;
-import com.sonian.elasticsearch.http.filter.FilterHttpServerTransportModule;
 import com.sonian.elasticsearch.http.jetty.AbstractJettyHttpServerTests;
 import com.sonian.elasticsearch.http.jetty.HttpClientResponse;
-import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
-import org.elasticsearch.common.logging.log4j.Log4jESLoggerFactory;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.node.internal.InternalNode;
@@ -31,8 +27,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 import static com.sonian.elasticsearch.http.filter.logging.RequestLoggingLevel.Level.*;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
@@ -52,7 +46,7 @@ public class LoggingFilterHttpServerAdapterTests extends AbstractJettyHttpServer
         mockESLoggerFactory = new MockESLoggerFactory("INFO", "com.sonian.elasticsearch.http.filter.logging");
         ESLoggerFactory.setDefaultFactory(mockESLoggerFactory);
         putDefaultSettings(ImmutableSettings.settingsBuilder()
-                .put("http.type", FilterHttpServerTransportModule.class.getName())
+                .put("http.type", FilterHttpServerTransport.class.getName())
         );
     }
 

--- a/src/test/java/com/sonian/elasticsearch/http/filter/logging/LoggingFilterHttpServerAdapterTests.java
+++ b/src/test/java/com/sonian/elasticsearch/http/filter/logging/LoggingFilterHttpServerAdapterTests.java
@@ -46,7 +46,7 @@ public class LoggingFilterHttpServerAdapterTests extends AbstractJettyHttpServer
         mockESLoggerFactory = new MockESLoggerFactory("INFO", "com.sonian.elasticsearch.http.filter.logging");
         ESLoggerFactory.setDefaultFactory(mockESLoggerFactory);
         putDefaultSettings(ImmutableSettings.settingsBuilder()
-                .put("http.type", FilterHttpServerTransport.class.getName())
+                .put("sonian.elasticsearch.http.type", FilterHttpServerTransport.class.getName())
         );
     }
 

--- a/src/test/java/com/sonian/elasticsearch/http/jetty/AbstractJettyHttpServerTests.java
+++ b/src/test/java/com/sonian/elasticsearch/http/jetty/AbstractJettyHttpServerTests.java
@@ -52,7 +52,6 @@ public class AbstractJettyHttpServerTests {
     private Settings defaultSettings = ImmutableSettings
             .settingsBuilder()
             .put("cluster.name", "test-cluster-" + NetworkUtils.getLocalAddress().getHostName())
-            .put("http.type", JettyHttpServerTransport.class.getName())
             .put("sonian.elasticsearch.http.jetty.port", "9290-9300")
             .put("node.local", true)
             .put("gateway.type", "none")

--- a/src/test/java/com/sonian/elasticsearch/http/jetty/AbstractJettyHttpServerTests.java
+++ b/src/test/java/com/sonian/elasticsearch/http/jetty/AbstractJettyHttpServerTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.internal.InternalNode;
+import org.elasticsearch.plugins.PluginsService;
 
 import java.util.Map;
 import java.util.Set;
@@ -51,11 +52,12 @@ public class AbstractJettyHttpServerTests {
     private Settings defaultSettings = ImmutableSettings
             .settingsBuilder()
             .put("cluster.name", "test-cluster-" + NetworkUtils.getLocalAddress().getHostName())
-            .put("http.type", JettyHttpServerTransportModule.class.getName())
+            .put("http.type", JettyHttpServerTransport.class.getName())
             .put("sonian.elasticsearch.http.jetty.port", "9290-9300")
             .put("node.local", true)
             .put("gateway.type", "none")
             .put("index.store.type", "memory")
+            .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
             .build();
 
     public void putDefaultSettings(Settings.Builder settings) {

--- a/src/test/java/com/sonian/elasticsearch/plugin/jetty/JettyPluginTests.java
+++ b/src/test/java/com/sonian/elasticsearch/plugin/jetty/JettyPluginTests.java
@@ -1,0 +1,218 @@
+package com.sonian.elasticsearch.plugin.jetty;
+
+import com.sonian.elasticsearch.http.filter.FilterHttpServerTransport;
+import com.sonian.elasticsearch.http.filter.FilterHttpServerTransportModule;
+import com.sonian.elasticsearch.http.jetty.JettyHttpServerTransport;
+import com.sonian.elasticsearch.http.jetty.JettyHttpServerTransportModule;
+import org.easymock.EasyMock;
+import org.elasticsearch.common.inject.Binder;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.inject.binder.AnnotatedBindingBuilder;
+import org.elasticsearch.common.inject.binder.ScopedBindingBuilder;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.NoClassSettingsException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpServer;
+import org.elasticsearch.http.HttpServerModule;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.http.netty.NettyHttpServerTransport;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class JettyPluginTests {
+
+    @Test
+    public void testModulesWithNoHttpType() throws Exception {
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+
+        // when
+        Collection<Class<? extends Module>> modules = plugin.modules();
+
+        assertThat(
+                modules.size(),
+                equalTo(1)
+        );
+
+        Class expectedClass = JettyHttpServerTransportModule.class;
+        Class actualClass = (Class)modules.toArray()[0];
+        assertThat(
+                "Expected class: " + expectedClass.getName() +
+                        " Actual class: " + actualClass.getName(),
+                modules.contains(expectedClass)
+        );
+    }
+
+    @Test
+    public void testModulesWithHttpTypeNettyOverridesAltType() throws Exception {
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .put("http.type", NettyHttpServerTransport.class.getName())
+                .put("sonian.elasticsearch.http.type", JettyHttpServerTransport.class.getName())
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+
+        // when
+        Collection<Class<? extends Module>> modules = plugin.modules();
+
+        assertThat(
+                modules.size(),
+                equalTo(0)
+        );
+    }
+
+
+
+    @Test
+    public void testModulesWithHttpTypeJetty() throws Exception {
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .put("http.type", JettyHttpServerTransport.class.getName())
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+
+        // when
+        Collection<Class<? extends Module>> modules = plugin.modules();
+
+        assertThat(
+                modules.size(),
+                equalTo(1)
+        );
+
+        Class expectedClass = JettyHttpServerTransportModule.class;
+        Class actualClass = (Class)modules.toArray()[0];
+        assertThat(
+                "Expected class: " + expectedClass.getName() +
+                        " Actual class: " + actualClass.getName(),
+                modules.contains(expectedClass)
+        );
+    }
+
+    @Test
+    public void testModulesWithAltHttpTypeJetty() throws Exception {
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .put("sonian.elasticsearch.http.type", JettyHttpServerTransport.class.getName())
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+
+        // when
+        Collection<Class<? extends Module>> modules = plugin.modules();
+
+        assertThat(
+                modules.size(),
+                equalTo(1)
+        );
+
+        Class expectedClass = JettyHttpServerTransportModule.class;
+        Class actualClass = (Class)modules.toArray()[0];
+        assertThat(
+                "Expected class: " + expectedClass.getName() +
+                        " Actual class: " + actualClass.getName(),
+                modules.contains(expectedClass)
+        );
+    }
+
+    @Test
+    public void testModulesWithHttpTypeFilter() throws Exception {
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .put("http.type", FilterHttpServerTransport.class.getName())
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+
+        // when
+        Collection<Class<? extends Module>> modules = plugin.modules();
+
+        assertThat(
+                modules.size(),
+                equalTo(1)
+        );
+
+        Class expectedClass = FilterHttpServerTransportModule.class;
+        Class actualClass = (Class)modules.toArray()[0];
+        assertThat(
+                "Expected class: " + expectedClass.getName() +
+                        " Actual class: " + actualClass.getName(),
+                modules.contains(expectedClass)
+        );
+    }
+
+    @Test
+    public void testModulesWithAltHttpTypeFilter() throws Exception {
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .put("sonian.elasticsearch.http.type", FilterHttpServerTransport.class.getName())
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+
+        // when
+        Collection<Class<? extends Module>> modules = plugin.modules();
+
+        assertThat(
+                modules.size(),
+                equalTo(1)
+        );
+
+        Class expectedClass = FilterHttpServerTransportModule.class;
+        Class actualClass = (Class)modules.toArray()[0];
+        assertThat(
+                "Expected class: " + expectedClass.getName() +
+                        " Actual class: " + actualClass.getName(),
+                modules.contains(expectedClass)
+        );
+    }
+
+    @Test
+    public void testModulesThrowsExceptionWithBadHttpType() throws Exception {
+        String badClass = JettyHttpServerTransport.class.getPackage().getName() + ".JttyHttpServerTransport";
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .put("http.type", badClass)
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+
+        try {
+            plugin.modules();
+        } catch (NoClassSettingsException ex) {
+            assertThat(ex.getMessage(), equalTo("Failed to load class setting [http.type] with value [" + badClass + "]"));
+        }
+    }
+
+    @Test
+    public void testOnModuleInjectsTransportIntoHttpServerModule() {
+        Settings settings = ImmutableSettings
+                .settingsBuilder()
+                .build();
+        JettyPlugin plugin = new JettyPlugin(settings);
+        plugin.modules();
+
+        HttpServerModule httpServerModule = new HttpServerModule(settings);
+        plugin.onModule(httpServerModule);
+
+        // mock out bind calls
+        Class expectedTransportClass = JettyHttpServerTransport.class;
+        Binder binderMock = EasyMock.createMock(Binder.class);
+        @SuppressWarnings("unchecked")
+        AnnotatedBindingBuilder abb = EasyMock.createMock(AnnotatedBindingBuilder.class);
+        ScopedBindingBuilder sbb = EasyMock.createMock(ScopedBindingBuilder.class);
+        EasyMock.expect(binderMock.bind(HttpServerTransport.class)).andReturn(abb);
+        EasyMock.expect(abb.to(expectedTransportClass)).andReturn(sbb);
+        sbb.asEagerSingleton();
+        EasyMock.expect(binderMock.bind(HttpServer.class)).andReturn(abb);
+        abb.asEagerSingleton();
+        EasyMock.expectLastCall();
+
+        // call configure
+        EasyMock.replay(binderMock);
+        EasyMock.replay(abb);
+        EasyMock.replay(sbb);
+        httpServerModule.configure(binderMock);
+    }
+}


### PR DESCRIPTION
I changed how this plugin gets bound in Guice so it works with ES v1.4. I also added some minor tweaks that will allow this plugin to work with the Jetty transport without any configuration.